### PR TITLE
Fix CoffeeScript CJS + ESM

### DIFF
--- a/coffeescript-loader/loader.js
+++ b/coffeescript-loader/loader.js
@@ -5,7 +5,7 @@ import { dirname, extname, resolve as resolvePath } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import CoffeeScript from 'coffeescript';
-const compile = (source, filename) => CoffeeScript.compile(source, {
+const coffeeCompile = (source, filename) => CoffeeScript.compile(source, {
   bare: true,
   filename
 });
@@ -54,7 +54,7 @@ export async function load(url, context, defaultLoad) {
     const { source: rawSource } = await defaultLoad(url, { format });
     // This hook converts CoffeeScript source code into JavaScript source code
     // for all imported CoffeeScript files.
-    const transformedSource = compile(rawSource.toString(), url)
+    const transformedSource = coffeeCompile(rawSource.toString(), url)
 
     return {
       format,
@@ -93,6 +93,6 @@ const require = createRequire(import.meta.url);
 ['.coffee', '.litcoffee', '.coffee.md'].forEach(extension => {
   require.extensions[extension] = (module, filename) => {
     const source = readFileSync(filename, 'utf8');
-    return module._compile(compile(source, filename), filename);
+    return module._compile(coffeeCompile(source, filename), filename);
   }
 })

--- a/coffeescript-loader/loader.js
+++ b/coffeescript-loader/loader.js
@@ -5,7 +5,10 @@ import { dirname, extname, resolve as resolvePath } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import CoffeeScript from 'coffeescript';
-
+const compile = (source, filename) => CoffeeScript.compile(source, {
+  bare: true,
+  filename
+});
 
 const baseURL = pathToFileURL(process.cwd() + '/').href;
 
@@ -51,10 +54,7 @@ export async function load(url, context, defaultLoad) {
     const { source: rawSource } = await defaultLoad(url, { format });
     // This hook converts CoffeeScript source code into JavaScript source code
     // for all imported CoffeeScript files.
-    const transformedSource = CoffeeScript.compile(rawSource.toString(), {
-      bare: true,
-      filename: url,
-    });
+    const transformedSource = compile(rawSource.toString(), url)
 
     return {
       format,
@@ -93,6 +93,6 @@ const require = createRequire(import.meta.url);
 ['.coffee', '.litcoffee', '.coffee.md'].forEach(extension => {
   require.extensions[extension] = (module, filename) => {
     const source = readFileSync(filename, 'utf8');
-    return CoffeeScript.compile(source, { bare: true, filename });
+    return module._compile(compile(source, filename), filename);
   }
 })

--- a/coffeescript-loader/loader.js
+++ b/coffeescript-loader/loader.js
@@ -84,15 +84,6 @@ async function getPackageType(url) {
   return dir.length > 1 && getPackageType(resolvePath(dir, '..'));
 }
 
-
-// Register CoffeeScript to also transform CommonJS files. This can more
-// thoroughly be done for CoffeeScript specifically via
-// `CoffeeScript.register()`, but for purposes of this example this is the
-// simplest method.
+// Register CoffeeScript to also transform CommonJS files.
 const require = createRequire(import.meta.url);
-['.coffee', '.litcoffee', '.coffee.md'].forEach(extension => {
-  require.extensions[extension] = (module, filename) => {
-    const source = readFileSync(filename, 'utf8');
-    return module._compile(coffeeCompile(source, filename), filename);
-  }
-})
+require("coffeescript/register")

--- a/coffeescript-loader/loader.js
+++ b/coffeescript-loader/loader.js
@@ -1,5 +1,4 @@
 import { readFile } from 'fs/promises';
-import { readFileSync } from 'fs';
 import { createRequire } from 'module';
 import { dirname, extname, resolve as resolvePath } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';

--- a/coffeescript-loader/test.js
+++ b/coffeescript-loader/test.js
@@ -1,16 +1,14 @@
 import { ok } from 'assert';
 import { spawn } from 'child_process';
 import { execPath } from 'process';
-import { fileURLToPath, URL } from 'url';
-
 
 // Run this test yourself with debugging mode via:
 // node --inspect-brk --experimental-loader ./loader.js ./fixtures/esm-and-commonjs-imports.coffee
 
 const child = spawn(execPath, [
   '--experimental-loader',
-  fileURLToPath(new URL('./loader.js', import.meta.url).href),
-  fileURLToPath(new URL('./fixtures/esm-and-commonjs-imports.coffee', import.meta.url).href),
+  './loader.js',
+  './fixtures/esm-and-commonjs-imports.coffee',
 ]);
 let stdout = '';
 child.stdout.setEncoding('utf8');
@@ -24,12 +22,7 @@ child.stderr.on('data', (data) => {
 });
 
 child.on('close', (code, signal) => {
-  ok(stdout.includes('Hello from CoffeeScript', 'Main entry transpiles'));
+  ok(stdout.includes('Hello from CoffeeScript'), 'Main entry transpiles');
   ok(stdout.includes('HELLO FROM ESM'), 'ESM import transpiles');
-
-  // There is a known issue between ESM + CJS where CJS named exports get lost:
-  // require.extentions appropriately supplies (transformed) source, but an
-  // empty object is returned for the module's exports.
-  // the import does NOT hit ESMLoader or its CJS strategy.
-  ok(!stdout.includes('Hello from CommonJS!'), 'Named CommonJS import fails');
+  ok(stdout.includes('Hello from CommonJS!'), 'Named CommonJS import fails');
 });


### PR DESCRIPTION
Added call to `module._compile` to fix CJS loading in combo mode.

Also refactored out `compile` helper method for compiling CoffeeScript.