### PR TITLE
feat: support loader chaining

### DIFF
--- a/coffeescript-loader/package-lock.json
+++ b/coffeescript-loader/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "coffeescript-loader",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/coffeescript-loader/test.js
+++ b/coffeescript-loader/test.js
@@ -1,28 +1,33 @@
-import { ok } from 'assert';
-import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { ok, strictEqual } from 'assert';
+import { spawnSync } from 'child_process';
 import { execPath } from 'process';
 
 // Run this test yourself with debugging mode via:
 // node --inspect-brk --experimental-loader ./loader.js ./fixtures/esm-and-commonjs-imports.coffee
 
-const child = spawn(execPath, [
-  '--experimental-loader',
+const loader = fileURLToPath(new URL(
   './loader.js',
+  import.meta.url
+));
+const fixture = fileURLToPath(new URL(
   './fixtures/esm-and-commonjs-imports.coffee',
-]);
-let stdout = '';
-child.stdout.setEncoding('utf8');
-child.stdout.on('data', (data) => {
-  stdout += data;
-});
-let stderr = '';
-child.stderr.setEncoding('utf8');
-child.stderr.on('data', (data) => {
-  stderr += data;
-});
+  import.meta.url
+));
 
-child.on('close', (code, signal) => {
-  ok(stdout.includes('Hello from CoffeeScript'), 'Main entry transpiles');
-  ok(stdout.includes('HELLO FROM ESM'), 'ESM import transpiles');
-  ok(stdout.includes('Hello from CommonJS!'), 'Named CommonJS import fails');
-});
+const { status, stderr, stdout } = spawnSync(
+  execPath,
+  [
+    '--experimental-loader',
+    loader,
+    fixture,
+  ],
+  { encoding: 'utf8' },
+);
+
+console.error(stderr);
+
+strictEqual(status, 0);
+ok(stdout.includes('Hello from CoffeeScript'), 'Main entry transpiles');
+ok(stdout.includes('HELLO FROM ESM'), 'ESM import transpiles');
+ok(stdout.includes('Hello from CommonJS!'), 'Named CommonJS import fails');

--- a/https-loader/test.js
+++ b/https-loader/test.js
@@ -1,24 +1,32 @@
-import { ok } from 'assert';
-import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { ok, strictEqual } from 'assert';
+import { spawnSync } from 'child_process';
 import { execPath } from 'process';
-import { fileURLToPath, URL } from 'url';
-
 
 // Run this test yourself with debugging mode via:
 // node --inspect-brk --experimental-loader ./loader.js ./fixture.js
 
-const child = spawn(execPath, [
-  '--experimental-loader',
-  fileURLToPath(new URL('./loader.js', import.meta.url).href),
-  fileURLToPath(new URL('./fixture.js', import.meta.url).href),
-]);
+const loader = fileURLToPath(new URL(
+  './loader.js',
+  import.meta.url
+));
+const fixture = fileURLToPath(new URL(
+  './fixture.js',
+  import.meta.url
+));
 
-let stdout = '';
-child.stdout.setEncoding('utf8');
-child.stdout.on('data', (data) => {
-  stdout += data;
-});
+const { status, stderr, stdout } = spawnSync(
+  execPath,
+  [
+    '--experimental-loader',
+    loader,
+    fixture,
+  ],
+  { encoding: 'utf8' },
+);
 
-child.on('close', (code, signal) => {
-  ok(/The browser-based version of CoffeeScript hosted at coffeescript\.org is: \d+\.\d+\.\d+/.test(stdout.toString()));
-});
+console.error(stderr);
+
+
+strictEqual(status, 0);
+ok(/The browser-based version of CoffeeScript hosted at coffeescript\.org is: \d+\.\d+\.\d+/.test(stdout.toString()));


### PR DESCRIPTION
tested against nodejs/node#42623 as of [15eecb6](https://github.com/nodejs/node/pull/42623/commits/15eecb6284c970b1425e97319fedc2789758c586)

Both `coffeescript-loader/test.js` and `https-loader/test.js` pass