### PR TITLE
Add loader supporting mixed-format packages

### DIFF
--- a/mixed-format/fixture/cjs.js
+++ b/mixed-format/fixture/cjs.js
@@ -1,1 +1,1 @@
-exports.qux = 'zed';
+exports.qux = require('./cjs2.js');

--- a/mixed-format/fixture/cjs.js
+++ b/mixed-format/fixture/cjs.js
@@ -1,0 +1,1 @@
+exports.qux = 'zed';

--- a/mixed-format/fixture/cjs2.js
+++ b/mixed-format/fixture/cjs2.js
@@ -1,0 +1,1 @@
+module.exports = 'zed';

--- a/mixed-format/fixture/esm.js
+++ b/mixed-format/fixture/esm.js
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/mixed-format/fixture/package.json
+++ b/mixed-format/fixture/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}

--- a/mixed-format/loader.mjs
+++ b/mixed-format/loader.mjs
@@ -24,7 +24,8 @@ export async function load(url, context, nextLoad) {
 function containsCJS(source) {
   const src = '' + source;
 
-  if (src.match(/exports[\.( ?=)]/)) return true;
+  // A realistic version of this loader would use a parser like Acorn to check for actual `module.exports` syntax
+  if (src.match(/exports[\.( ?=)]/)) { return true };
 
   if (
     src.match(/require\(/)

--- a/mixed-format/loader.mjs
+++ b/mixed-format/loader.mjs
@@ -1,0 +1,23 @@
+export async function load(url, context, nextLoad) {
+  if (!url.endsWith('.js')) return nextLoad(url);
+
+  const nextResult = await nextLoad(url, { ...context, format: 'module' })
+    .then((result) => {
+      if (`${result.source}`.match(/exports[\. =]/)) throw new Error('Module is commonjs');
+
+      return result;
+    })
+    .catch(async (err) => {
+      if (
+        (err?.message.includes('require') && err.includes('import'))
+        || err?.message.includes('commonjs')
+      ) return {
+        format: 'commonjs',
+        source: (await nextLoad(url, {...context, format: 'commonjs' })).source,
+      };
+
+      throw err;
+    });
+
+  return nextResult;
+}

--- a/mixed-format/test.mjs
+++ b/mixed-format/test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+import { foo } from './fixture/esm.js';
+import { qux } from './fixture/cjs.js';
+
+
+assert.strictEqual(foo, 'bar');
+assert.strictEqual(qux, 'zed');


### PR DESCRIPTION
This loader enables (with non-robust checks) loading both CJS and ESM from the same package where the package declares a single type.

This is a common scenario in older packages that distribute both CJS and ESM yet mark themselves as commonjs (either by omission of `"type"` or by relying on the non-standard `"module"` field).

Depends on https://github.com/nodejs/node/pull/44396