### PR TITLE
Fix commonjs-extension-resolution-loader

### DIFF
--- a/commonjs-extension-resolution-loader/package-lock.json
+++ b/commonjs-extension-resolution-loader/package-lock.json
@@ -1,0 +1,118 @@
+{
+  "name": "commonjs-extension-resolution-loader",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "commonjs-extension-resolution-loader",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.22.1"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  },
+  "dependencies": {
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    }
+  }
+}

--- a/commonjs-extension-resolution-loader/package.json
+++ b/commonjs-extension-resolution-loader/package.json
@@ -8,6 +8,9 @@
     "start": "npm test",
     "test": "node test.js"
   },
-  "author": "Geoffrey Booth <webmaster@geoffreybooth.com>",
-  "license": "MIT"
+  "author": "Geoffrey Booth <webadmin@geoffreybooth.com>",
+  "license": "MIT",
+  "dependencies": {
+    "resolve": "^1.22.1"
+  }
 }

--- a/commonjs-extension-resolution-loader/test.js
+++ b/commonjs-extension-resolution-loader/test.js
@@ -1,13 +1,13 @@
-import { ok } from 'assert';
+import { match } from 'assert';
 import { spawn } from 'child_process';
 import { execPath } from 'process';
 
 
 // Run this test yourself with debugging mode via:
-// node --inspect-brk --experimental-loader ./loader.js ./fixtures/index.js
+// node --inspect-brk --loader ./loader.js ./fixtures/index.js
 
 const child = spawn(execPath, [
-  '--experimental-loader',
+  '--loader',
   './loader.js',
   './fixtures/index.js'
 ]);
@@ -20,6 +20,6 @@ child.stdout.on('data', (data) => {
 
 child.on('close', (code, signal) => {
 	stdout = stdout.toString();
-  ok(stdout.includes('hello from file.js'));
-  ok(stdout.includes('hello from folder/index.js'));
+  match(stdout, /hello from file\.js/);
+  match(stdout, /hello from folder\/index\.js/);
 });

--- a/commonjs-extension-resolution-loader/test.js
+++ b/commonjs-extension-resolution-loader/test.js
@@ -14,12 +14,12 @@ const child = spawn(execPath, [
 
 let stdout = '';
 child.stdout.setEncoding('utf8');
-child.stdout.on('data', (data) => {
+child.stdout.on('data', data => {
   stdout += data;
 });
 
-child.on('close', (code, signal) => {
-	stdout = stdout.toString();
+child.on('close', (_code, _signal) => {
+  stdout = stdout.toString();
   match(stdout, /hello from file\.js/);
   match(stdout, /hello from folder\/index\.js/);
 });


### PR DESCRIPTION
This loader should never have been part of the original repo, since it didn’t work 😄 

This PR simply gets this loader working per its own test. As a follow-up I’d like to add all the Node codebase tests for `--experimental-specifier-resolution=node` to ensure that they all pass with this loader.